### PR TITLE
Rewrite Chunk Section Packets to allow heights above 512(Vanilla Limit).

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,10 @@ dependencies {
     // You may need to force-disable transitiveness on them.
 }
 
+minecraft {
+    accessWidener = file("src/main/resources/whb.aw")
+}
+
 processResources {
     inputs.property "version", project.version
 

--- a/src/main/java/dev/soapy/worldheightbooster/WorldHeightBooster.java
+++ b/src/main/java/dev/soapy/worldheightbooster/WorldHeightBooster.java
@@ -2,12 +2,11 @@ package dev.soapy.worldheightbooster;
 
 import net.fabricmc.api.ModInitializer;
 
-import java.util.logging.LogManager;
 import java.util.logging.Logger;
 
 public class WorldHeightBooster implements ModInitializer {
     // replace this with config when config mods exist again
-    public static final int WORLD_HEIGHT = 512;
+    public static final int WORLD_HEIGHT = 768;
     public static final int MIN_Y = 0;
 
     public static final Logger LOGGER = Logger.getLogger("worldheightbooster");

--- a/src/main/java/dev/soapy/worldheightbooster/getterintefaces/bigchunkpacket/BitStorageChunkPacketDataClientChunkCache.java
+++ b/src/main/java/dev/soapy/worldheightbooster/getterintefaces/bigchunkpacket/BitStorageChunkPacketDataClientChunkCache.java
@@ -1,0 +1,14 @@
+package dev.soapy.worldheightbooster.getterintefaces.bigchunkpacket;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.util.BitStorage;
+import net.minecraft.world.level.chunk.ChunkBiomeContainer;
+import net.minecraft.world.level.chunk.LevelChunk;
+import org.jetbrains.annotations.Nullable;
+
+public interface BitStorageChunkPacketDataClientChunkCache {
+
+    @Nullable
+    LevelChunk replaceWithBitStoragePacketData(int i, int j, @Nullable ChunkBiomeContainer chunkBiomeContainer, FriendlyByteBuf friendlyByteBuf, CompoundTag compoundTag, BitStorage bitStorage);
+}

--- a/src/main/java/dev/soapy/worldheightbooster/getterintefaces/bigchunkpacket/BitStorageChunkPacketDataLevelChunk.java
+++ b/src/main/java/dev/soapy/worldheightbooster/getterintefaces/bigchunkpacket/BitStorageChunkPacketDataLevelChunk.java
@@ -1,0 +1,15 @@
+package dev.soapy.worldheightbooster.getterintefaces.bigchunkpacket;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.util.BitStorage;
+import net.minecraft.world.level.chunk.ChunkBiomeContainer;
+import org.jetbrains.annotations.Nullable;
+
+public interface BitStorageChunkPacketDataLevelChunk {
+
+    @Environment(EnvType.CLIENT)
+    void replaceWithBitStoragePacketData(@Nullable ChunkBiomeContainer chunkBiomeContainer, FriendlyByteBuf friendlyByteBuf, CompoundTag compoundTag, BitStorage bitStorage);
+}

--- a/src/main/java/dev/soapy/worldheightbooster/getterintefaces/bigchunkpacket/BitStorageGetter.java
+++ b/src/main/java/dev/soapy/worldheightbooster/getterintefaces/bigchunkpacket/BitStorageGetter.java
@@ -1,0 +1,8 @@
+package dev.soapy.worldheightbooster.getterintefaces.bigchunkpacket;
+
+import net.minecraft.util.BitStorage;
+
+public interface BitStorageGetter {
+
+    BitStorage getBitStorage();
+}

--- a/src/main/java/dev/soapy/worldheightbooster/mixin/bigchunkpacket/bigchunkpacket/MixinClientBoundChunkPacket.java
+++ b/src/main/java/dev/soapy/worldheightbooster/mixin/bigchunkpacket/bigchunkpacket/MixinClientBoundChunkPacket.java
@@ -1,0 +1,58 @@
+package dev.soapy.worldheightbooster.mixin.bigchunkpacket.bigchunkpacket;
+
+import dev.soapy.worldheightbooster.getterintefaces.bigchunkpacket.BitStorageGetter;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.protocol.game.ClientboundLevelChunkPacket;
+import net.minecraft.util.BitStorage;
+import net.minecraft.world.level.chunk.LevelChunk;
+import net.minecraft.world.level.chunk.LevelChunkSection;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ClientboundLevelChunkPacket.class)
+public abstract class MixinClientBoundChunkPacket implements BitStorageGetter {
+
+    @Shadow protected abstract ByteBuf getWriteBuffer();
+
+    private BitStorage extendedSectionBitStorage;
+
+    @Inject(at = @At("RETURN"), method = "<init>(Lnet/minecraft/world/level/chunk/LevelChunk;)V")
+    private void rewriteChunKData(LevelChunk levelChunk, CallbackInfo ci) {
+        this.extendedSectionBitStorage = this.extractExtendedSectionChunkData(new FriendlyByteBuf(this.getWriteBuffer()), levelChunk);
+    }
+
+    private BitStorage extractExtendedSectionChunkData(FriendlyByteBuf friendlyByteBuf, LevelChunk levelChunk) {
+        LevelChunkSection[] levelChunkSections = levelChunk.getSections();
+        int chunkSectionIDX = 0;
+        BitStorage sectionBitStorage = new BitStorage(1, levelChunkSections.length, null);
+
+        for(int sectionsLength = levelChunkSections.length; chunkSectionIDX < sectionsLength; ++chunkSectionIDX) {
+            LevelChunkSection levelChunkSection = levelChunkSections[chunkSectionIDX];
+            if (levelChunkSection != LevelChunk.EMPTY_SECTION && !levelChunkSection.isEmpty()) {
+                sectionBitStorage.set(chunkSectionIDX, 1);
+                levelChunkSection.write(friendlyByteBuf);
+            }
+        }
+        return sectionBitStorage;
+    }
+
+
+    @Inject(at = @At("RETURN"), method = "write(Lnet/minecraft/network/FriendlyByteBuf;)V")
+    private void writeExtendedSectionStorage(FriendlyByteBuf friendlyByteBuf, CallbackInfo ci) {
+        friendlyByteBuf.writeLongArray(this.extendedSectionBitStorage.getRaw());
+    }
+
+    @Inject(at = @At("RETURN"), method = "read(Lnet/minecraft/network/FriendlyByteBuf;)V")
+    private void readExtendedSectionStorage(FriendlyByteBuf friendlyByteBuf, CallbackInfo ci) {
+        friendlyByteBuf.readLongArray(this.extendedSectionBitStorage.getRaw());
+    }
+
+    @Override
+    public BitStorage getBitStorage() {
+        return this.extendedSectionBitStorage;
+    }
+}

--- a/src/main/java/dev/soapy/worldheightbooster/mixin/bigchunkpacket/bigchunkpacket/MixinClientChunkCache.java
+++ b/src/main/java/dev/soapy/worldheightbooster/mixin/bigchunkpacket/bigchunkpacket/MixinClientChunkCache.java
@@ -1,0 +1,72 @@
+package dev.soapy.worldheightbooster.mixin.bigchunkpacket.bigchunkpacket;
+
+
+import dev.soapy.worldheightbooster.getterintefaces.bigchunkpacket.BitStorageChunkPacketDataClientChunkCache;
+import dev.soapy.worldheightbooster.getterintefaces.bigchunkpacket.BitStorageChunkPacketDataLevelChunk;
+import net.minecraft.client.multiplayer.ClientChunkCache;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.core.SectionPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.util.BitStorage;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.chunk.ChunkBiomeContainer;
+import net.minecraft.world.level.chunk.LevelChunk;
+import net.minecraft.world.level.chunk.LevelChunkSection;
+import net.minecraft.world.level.lighting.LevelLightEngine;
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+@Mixin(ClientChunkCache.class)
+public abstract class MixinClientChunkCache implements BitStorageChunkPacketDataClientChunkCache {
+
+
+    @Shadow private volatile ClientChunkCache.Storage storage;
+
+
+    @Shadow @Final private static Logger LOGGER;
+
+    @Shadow @Final private ClientLevel level;
+
+    @Shadow public abstract LevelLightEngine getLightEngine();
+
+    @Override
+    public LevelChunk replaceWithBitStoragePacketData(int i, int j, @Nullable ChunkBiomeContainer chunkBiomeContainer, FriendlyByteBuf friendlyByteBuf, CompoundTag compoundTag, BitStorage bitStorage) {
+        if (!this.storage.inRange(i, j)) {
+            LOGGER.warn("Ignoring chunk since it's not in the view range: {}, {}", i, j);
+            return null;
+        } else {
+            int l = this.storage.getIndex(i, j);
+            LevelChunk levelChunk = (LevelChunk)this.storage.chunks.get(l);
+            ChunkPos chunkPos = new ChunkPos(i, j);
+            if (!ClientChunkCache.isValidChunk(levelChunk, i, j)) {
+                if (chunkBiomeContainer == null) {
+                    LOGGER.warn("Ignoring chunk since we don't have complete data: {}, {}", i, j);
+                    return null;
+                }
+
+                levelChunk = new LevelChunk(this.level, chunkPos, chunkBiomeContainer);
+                ((BitStorageChunkPacketDataLevelChunk)levelChunk).replaceWithBitStoragePacketData(chunkBiomeContainer, friendlyByteBuf, compoundTag, bitStorage);
+                this.storage.replace(l, levelChunk);
+            } else {
+                ((BitStorageChunkPacketDataLevelChunk)levelChunk).replaceWithBitStoragePacketData(chunkBiomeContainer, friendlyByteBuf, compoundTag, bitStorage);
+            }
+
+            LevelChunkSection[] levelChunkSections = levelChunk.getSections();
+            LevelLightEngine levelLightEngine = this.getLightEngine();
+            levelLightEngine.enableLightSources(chunkPos, true);
+
+            for(int m = 0; m < levelChunkSections.length; ++m) {
+                LevelChunkSection levelChunkSection = levelChunkSections[m];
+                int n = this.level.getSectionYFromSectionIndex(m);
+                levelLightEngine.updateSectionStatus(SectionPos.of(i, n, j), LevelChunkSection.isEmpty(levelChunkSection));
+            }
+
+            this.level.onChunkLoaded(chunkPos);
+            return levelChunk;
+        }
+    }
+}

--- a/src/main/java/dev/soapy/worldheightbooster/mixin/bigchunkpacket/bigchunkpacket/MixinClientPacketListener.java
+++ b/src/main/java/dev/soapy/worldheightbooster/mixin/bigchunkpacket/bigchunkpacket/MixinClientPacketListener.java
@@ -1,0 +1,57 @@
+package dev.soapy.worldheightbooster.mixin.bigchunkpacket.bigchunkpacket;
+
+import dev.soapy.worldheightbooster.getterintefaces.bigchunkpacket.BitStorageChunkPacketDataClientChunkCache;
+import dev.soapy.worldheightbooster.getterintefaces.bigchunkpacket.BitStorageGetter;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.client.multiplayer.ClientPacketListener;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Registry;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.protocol.PacketUtils;
+import net.minecraft.network.protocol.game.ClientboundLevelChunkPacket;
+import net.minecraft.util.thread.BlockableEventLoop;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.chunk.ChunkBiomeContainer;
+import net.minecraft.world.level.chunk.LevelChunk;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+
+@Mixin(ClientPacketListener.class)
+public abstract class MixinClientPacketListener {
+
+    @Shadow @Final private Minecraft minecraft;
+
+    @Shadow private RegistryAccess registryAccess;
+
+    @Shadow private ClientLevel level;
+
+    /**
+     * @author CorgiTaco
+     */
+    @Overwrite
+    public void handleLevelChunk(ClientboundLevelChunkPacket clientboundLevelChunkPacket) {
+        PacketUtils.ensureRunningOnSameThread(clientboundLevelChunkPacket, ((ClientPacketListener)(Object)this), (BlockableEventLoop)this.minecraft);
+        int i = clientboundLevelChunkPacket.getX();
+        int j = clientboundLevelChunkPacket.getZ();
+        ChunkBiomeContainer chunkBiomeContainer = clientboundLevelChunkPacket.getBiomes() == null ? null : new ChunkBiomeContainer(this.registryAccess.registryOrThrow(Registry.BIOME_REGISTRY), clientboundLevelChunkPacket.getBiomes());
+        LevelChunk levelChunk = ((BitStorageChunkPacketDataClientChunkCache) this.level.getChunkSource()).replaceWithBitStoragePacketData(i, j, chunkBiomeContainer, clientboundLevelChunkPacket.getReadBuffer(), clientboundLevelChunkPacket.getHeightmaps(), ((BitStorageGetter)clientboundLevelChunkPacket).getBitStorage());
+
+        for(int k = this.level.getMinSection(); k < this.level.getMaxSection(); ++k) {
+            this.level.setSectionDirtyWithNeighbors(i, k, j);
+        }
+
+        if (levelChunk != null) {
+            for (CompoundTag compoundTag : clientboundLevelChunkPacket.getBlockEntitiesTags()) {
+                BlockPos blockPos = new BlockPos(compoundTag.getInt("x"), compoundTag.getInt("y"), compoundTag.getInt("z"));
+                BlockEntity blockEntity = levelChunk.getBlockEntity(blockPos, LevelChunk.EntityCreationType.IMMEDIATE);
+                if (blockEntity != null) {
+                    blockEntity.load(compoundTag);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/dev/soapy/worldheightbooster/mixin/bigchunkpacket/bigchunkpacket/MixinLevelChunk.java
+++ b/src/main/java/dev/soapy/worldheightbooster/mixin/bigchunkpacket/bigchunkpacket/MixinLevelChunk.java
@@ -18,7 +18,7 @@ import org.spongepowered.asm.mixin.Shadow;
 import java.util.Map;
 
 @Mixin(LevelChunk.class)
-public abstract class MixinLevelChunkLevelChunk implements BitStorageChunkPacketDataLevelChunk {
+public abstract class MixinLevelChunk implements BitStorageChunkPacketDataLevelChunk {
 
 
     @Shadow @Final private Map<BlockPos, BlockEntity> blockEntities;

--- a/src/main/java/dev/soapy/worldheightbooster/mixin/bigchunkpacket/bigchunkpacket/MixinLevelChunkLevelChunk.java
+++ b/src/main/java/dev/soapy/worldheightbooster/mixin/bigchunkpacket/bigchunkpacket/MixinLevelChunkLevelChunk.java
@@ -1,0 +1,83 @@
+package dev.soapy.worldheightbooster.mixin.bigchunkpacket.bigchunkpacket;
+
+import dev.soapy.worldheightbooster.getterintefaces.bigchunkpacket.BitStorageChunkPacketDataLevelChunk;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.util.BitStorage;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.chunk.ChunkBiomeContainer;
+import net.minecraft.world.level.chunk.LevelChunk;
+import net.minecraft.world.level.chunk.LevelChunkSection;
+import net.minecraft.world.level.levelgen.Heightmap;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+import java.util.Map;
+
+@Mixin(LevelChunk.class)
+public abstract class MixinLevelChunkLevelChunk implements BitStorageChunkPacketDataLevelChunk {
+
+
+    @Shadow @Final private Map<BlockPos, BlockEntity> blockEntities;
+
+    @Shadow protected abstract void onBlockEntityRemove(BlockEntity blockEntity);
+
+    @Shadow @Final private LevelChunkSection[] sections;
+
+    @Shadow @Final @Nullable public static LevelChunkSection EMPTY_SECTION;
+
+    @Shadow public abstract void setHeightmap(Heightmap.Types types, long[] ls);
+
+    @Shadow private ChunkBiomeContainer biomes;
+
+    @Override
+    public void replaceWithBitStoragePacketData(@Nullable ChunkBiomeContainer chunkBiomeContainer, FriendlyByteBuf friendlyByteBuf, CompoundTag compoundTag, BitStorage bitStorage) {
+        boolean bl = chunkBiomeContainer != null;
+        if (bl) {
+            this.blockEntities.values().forEach(this::onBlockEntityRemove);
+            this.blockEntities.clear();
+        } else {
+            this.blockEntities.values().removeIf((blockEntity) -> {
+                if (bitStorage.get(((LevelChunk)(Object)this).getSectionIndex(blockEntity.getBlockPos().getY())) != 0) {
+                    blockEntity.setRemoved();
+                    return true;
+                } else {
+                    return false;
+                }
+            });
+        }
+
+        for(int j = 0; j < this.sections.length; ++j) {
+            LevelChunkSection levelChunkSection = this.sections[j];
+            if ((bitStorage.get(j)) == 0) {
+                if (bl && levelChunkSection != EMPTY_SECTION) {
+                    this.sections[j] = EMPTY_SECTION;
+                }
+            } else {
+                if (levelChunkSection == EMPTY_SECTION) {
+                    levelChunkSection = new LevelChunkSection(((LevelChunk)(Object)this).getSectionYFromSectionIndex(j));
+                    this.sections[j] = levelChunkSection;
+                }
+
+                levelChunkSection.read(friendlyByteBuf);
+            }
+        }
+
+        if (chunkBiomeContainer != null) {
+            this.biomes = chunkBiomeContainer;
+        }
+
+        Heightmap.Types[] var11 = Heightmap.Types.values();
+        int var12 = var11.length;
+
+        for (Heightmap.Types types : var11) {
+            String string = types.getSerializationKey();
+            if (compoundTag.contains(string, 12)) {
+                this.setHeightmap(types, compoundTag.getLongArray(string));
+            }
+        }
+    }
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -21,5 +21,6 @@
   "depends": {
     "fabricloader": ">=0.10.6+build.214",
     "minecraft": ">=1.17-alpha.20.45.a"
-  }
+  },
+  "accessWidener": "whb.aw"
 }

--- a/src/main/resources/whb.aw
+++ b/src/main/resources/whb.aw
@@ -1,0 +1,8 @@
+accessWidener v1 named
+
+accessible method net/minecraft/client/multiplayer/ClientChunkCache isValidChunk (Lnet/minecraft/world/level/chunk/LevelChunk;II)Z
+accessible class net/minecraft/client/multiplayer/ClientChunkCache$Storage
+accessible field net/minecraft/client/multiplayer/ClientChunkCache$Storage chunks Ljava/util/concurrent/atomic/AtomicReferenceArray;
+accessible method net/minecraft/client/multiplayer/ClientChunkCache$Storage getIndex (II)I
+accessible method net/minecraft/client/multiplayer/ClientChunkCache$Storage inRange (II)Z
+accessible method net/minecraft/client/multiplayer/ClientChunkCache$Storage replace (ILnet/minecraft/world/level/chunk/LevelChunk;)V

--- a/src/main/resources/worldheightbooster.mixins.json
+++ b/src/main/resources/worldheightbooster.mixins.json
@@ -12,7 +12,11 @@
     "MixinNoiseSettings",
     "MixinProtoChunk",
     "MixinRavineCarver",
-    "MixinWorldHeight"
+    "MixinWorldHeight",
+    "bigchunkpacket.bigchunkpacket.MixinClientBoundChunkPacket",
+    "bigchunkpacket.bigchunkpacket.MixinClientChunkCache",
+    "bigchunkpacket.bigchunkpacket.MixinClientPacketListener",
+    "bigchunkpacket.bigchunkpacket.MixinLevelChunkLevelChunk"
   ],
   "client": [
     "MixinDefaultHeightLimit"

--- a/src/main/resources/worldheightbooster.mixins.json
+++ b/src/main/resources/worldheightbooster.mixins.json
@@ -16,7 +16,7 @@
     "bigchunkpacket.bigchunkpacket.MixinClientBoundChunkPacket",
     "bigchunkpacket.bigchunkpacket.MixinClientChunkCache",
     "bigchunkpacket.bigchunkpacket.MixinClientPacketListener",
-    "bigchunkpacket.bigchunkpacket.MixinLevelChunkLevelChunk"
+    "bigchunkpacket.bigchunkpacket.MixinLevelChunk"
   ],
   "client": [
     "MixinDefaultHeightLimit"


### PR DESCRIPTION
Everything works fine and dandy with 0 errors. I've used 768 in this PR feel free to switch it back to 512 :) This should give you more freedom to extend world height however you please. If you make the height 1024... it seems to throw an NPE somewhere along but that NPE DOES NOT crash your game. I'm not sure what causes this you may need to look along and figure that out or I will at some point.